### PR TITLE
Maybe fix essence streaks

### DIFF
--- a/src/main/java/com/github/maxopoly/essenceglue/StreakManager.java
+++ b/src/main/java/com/github/maxopoly/essenceglue/StreakManager.java
@@ -91,11 +91,11 @@ public class StreakManager {
 				EssenceGluePlugin.instance().getLogger().severe(p.getName() + " had main account in BanStick?");
 				continue;
 			}
+			updatePlayerStreak(uuid);
 			long sinceLastClaim = currentMillis - lastPlayerUpdate.getValue(uuid);
 			if (sinceLastClaim >= streakDelay) {
 				int currentCount = currentOnlineTime.computeIfAbsent(uuid, e -> 0);
 				if (currentCount >= countRequiredForGain && receiveRewards.getValue(p)) {
-					updatePlayerStreak(uuid);
 					currentOnlineTime.remove(uuid);
 					p.sendMessage(ChatColor.GREEN + "Your login streak is now " + ChatColor.LIGHT_PURPLE
 							+ getCurrentStreak(uuid, true));


### PR DESCRIPTION
@Maxopoly updatePlayerStreak was being called inside the if statement for players who can claim. This means that if you login after you can already claim, you would claim okay and your lastPlayerUpdate would update. However, if you log in before you can claim, lastPlayerUpdate was never being called and never updating, therefore if you logged in before the 20 hour window you never get the ability to claim. This may also explain why the "30 minutes to claim" was never decrementing either, because the lastPlayerUpdate was not changing?

This PR may not be ideal, just wanted to point out what I think the issue is.